### PR TITLE
Cache model results across option changes

### DIFF
--- a/R/med.b.R
+++ b/R/med.b.R
@@ -32,15 +32,31 @@ medClass <- R6::R6Class(
 
         #### Compute results ----
         .compute = function(data) {
-            model <- private$.lavaanify()
-            se <- self$options$estMethod
-            bootstrap <- self$options$bootstrap
+            # the estimates only depend on the variables, the estimation
+            # options and the CI level (the model cache's clearWith), so
+            # reuse them across other option changes -- refitting is
+            # expensive with bootstrap SEs. Only lavaan's estimates table is
+            # kept, so the state size does not grow with the data
+            est <- self$results$model$state
 
-            suppressWarnings({
-                fit <- lavaan::sem(model = model, data = data, se = se, bootstrap = bootstrap)
-            }) # suppressWarnings
+            if (is.null(est)) {
+                model <- private$.lavaanify()
+                se <- self$options$estMethod
+                bootstrap <- self$options$bootstrap
 
-            return(list('fit' = fit))
+                suppressWarnings({
+                    fit <- lavaan::sem(model = model, data = data, se = se, bootstrap = bootstrap)
+                }) # suppressWarnings
+
+                est <- lavaan::parameterestimates(
+                    fit,
+                    level = self$options$ciWidth / 100
+                )
+
+                self$results$model$setState(est)
+            }
+
+            return(list('est' = est))
         },
 
         #### Init tables/plots functions ----
@@ -106,11 +122,7 @@ medClass <- R6::R6Class(
         #### Populate tables ----
         .populateMedTable = function(results) {
             table <- self$results$med
-            est <- lavaan::parameterestimates(
-                results$fit,
-                standardized = TRUE,
-                level = self$options$ciWidth / 100
-            )
+            est <- results$est
 
             total <- abs(est[est$label == 'ab', 'est']) + abs(est[est$label == 'c', 'est'])
 
@@ -132,11 +144,7 @@ medClass <- R6::R6Class(
         },
         .populatePathsTable = function(results) {
             table <- self$results$paths
-            est <- lavaan::parameterestimates(
-                results$fit,
-                standardized = TRUE,
-                level = self$options$ciWidth / 100
-            )
+            est <- results$est
 
             labels <- c('a', 'b', 'c')
             for (i in seq_along(labels)) {
@@ -157,7 +165,7 @@ medClass <- R6::R6Class(
         #### Plot functions ----
         .preparePathDiagram = function(results) {
             image <- self$results$pathDiagram
-            est <- lavaan::parameterestimates(results$fit)
+            est <- results$est
 
             pathA <- lavaanRow(est, label = 'a')
             pathB <- lavaanRow(est, label = 'b')
@@ -224,11 +232,7 @@ medClass <- R6::R6Class(
         },
         .prepareEstPlot = function(results) {
             image <- self$results$estPlot
-            est <- lavaan::parameterestimates(
-                results$fit,
-                standardized = TRUE,
-                level = self$options$ciWidth / 100
-            )
+            est <- results$est
 
             labels <- c('ab', 'c', 'total')
             names <- c('Indirect', 'Direct', 'Total')

--- a/R/med.h.R
+++ b/R/med.h.R
@@ -170,6 +170,7 @@ medResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         paths = function() private$.items[["paths"]],
         pathDiagram = function() private$.items[["pathDiagram"]],
         estPlot = function() private$.items[["estPlot"]],
+        model = function() private$.items[["model"]],
         modelSyntax = function() private$..modelSyntax),
     private = list(
         ..modelSyntax = NA),
@@ -330,6 +331,17 @@ medResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "bootstrap",
                     "ciWidth",
                     "label")))
+            self$add(jmvcore::Preformatted$new(
+                options=options,
+                name="model",
+                visible=FALSE,
+                clearWith=list(
+                    "dep",
+                    "pred",
+                    "med",
+                    "estMethod",
+                    "bootstrap",
+                    "ciWidth")))
             private$..modelSyntax <- NULL},
         .setModelSyntax=function(x) private$..modelSyntax <- x))
 
@@ -416,6 +428,7 @@ medBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   \code{results$paths} \tab \tab \tab \tab \tab a table containing the individual path estimates \cr
 #'   \code{results$pathDiagram} \tab \tab \tab \tab \tab an image \cr
 #'   \code{results$estPlot} \tab \tab \tab \tab \tab an image \cr
+#'   \code{results$model} \tab \tab \tab \tab \tab invisible element whose state caches the parameter estimates so display-option changes do not refit the model \cr
 #'   \code{results$modelSyntax} \tab \tab \tab \tab \tab the lavaan syntax used to fit the mediation model \cr
 #' }
 #'

--- a/R/med.h.R
+++ b/R/med.h.R
@@ -187,7 +187,9 @@ medResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "dep",
                     "pred",
                     "med",
-                    "estMethod"),
+                    "estMethod",
+                    "bootstrap",
+                    "ciWidth"),
                 columns=list(
                     list(
                         `name`="effect", 
@@ -243,7 +245,9 @@ medResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "dep",
                     "pred",
                     "med",
-                    "estMethod"),
+                    "estMethod",
+                    "bootstrap",
+                    "ciWidth"),
                 columns=list(
                     list(
                         `name`="var1", 
@@ -308,7 +312,8 @@ medResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "pathDiagramEst",
                     "pathDiagramSig",
                     "med",
-                    "estMethod")))
+                    "estMethod",
+                    "bootstrap")))
             self$add(jmvcore::Image$new(
                 options=options,
                 name="estPlot",
@@ -322,6 +327,7 @@ medResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "pred",
                     "med",
                     "estMethod",
+                    "bootstrap",
                     "ciWidth",
                     "label")))
             private$..modelSyntax <- NULL},

--- a/R/mod.b.R
+++ b/R/mod.b.R
@@ -32,15 +32,31 @@ modClass <- R6::R6Class(
 
         #### Compute results ----
         .compute = function(data) {
-            model <- private$.lavaanify()
-            se <- self$options$estMethod
-            bootstrap <- self$options$bootstrap
+            # the estimates only depend on the variables, the estimation
+            # options and the CI level (the model cache's clearWith), so
+            # reuse them across other option changes -- refitting is
+            # expensive with bootstrap SEs. Only lavaan's estimates table is
+            # kept, so the state size does not grow with the data
+            est <- self$results$model$state
 
-            suppressWarnings({
-                fit <- lavaan::sem(model = model, data = data, se = se, bootstrap = bootstrap)
-            }) # suppressWarnings
+            if (is.null(est)) {
+                model <- private$.lavaanify()
+                se <- self$options$estMethod
+                bootstrap <- self$options$bootstrap
 
-            return(list('fit' = fit))
+                suppressWarnings({
+                    fit <- lavaan::sem(model = model, data = data, se = se, bootstrap = bootstrap)
+                }) # suppressWarnings
+
+                est <- lavaan::parameterestimates(
+                    fit,
+                    level = self$options$ciWidth / 100
+                )
+
+                self$results$model$setState(est)
+            }
+
+            return(list('est' = est))
         },
 
         #### Init tables/plots functions ----
@@ -100,11 +116,7 @@ modClass <- R6::R6Class(
         #### Populate tables ----
         .populateModTable = function(results) {
             table <- self$results$mod
-            est <- lavaan::parameterestimates(
-                results$fit,
-                standardized = TRUE,
-                level = self$options$ciWidth / 100
-            )
+            est <- results$est
 
             dep <- jmvcore::toB64(self$options$dep)
             pred <- jmvcore::toB64(self$options$pred)
@@ -128,11 +140,7 @@ modClass <- R6::R6Class(
         },
         .populateSimpleSlopeTable = function(results) {
             table <- self$results$simpleSlope$estimates
-            est <- lavaan::parameterestimates(
-                results$fit,
-                standardized = TRUE,
-                level = self$options$ciWidth / 100
-            )
+            est <- results$est
 
             labels <- c('mean', 'sdBelow', 'sdAbove')
             for (i in seq_along(labels)) {
@@ -153,7 +161,7 @@ modClass <- R6::R6Class(
         #### Plot functions ----
         .preparePathDiagram = function(results) {
             image <- self$results$pathDiagram
-            est <- lavaan::parameterestimates(results$fit)
+            est <- results$est
 
             b1 <- lavaanRow(est, label = 'b1')
             b2 <- lavaanRow(est, label = 'b2')
@@ -238,11 +246,7 @@ modClass <- R6::R6Class(
         },
         .prepareSimpleSlopePlot = function(data, results) {
             image <- self$results$simpleSlope$plot
-            est <- lavaan::parameterestimates(
-                results$fit,
-                standardized = TRUE,
-                level = self$options$ciWidth / 100
-            )
+            est <- results$est
 
             mod <- self$options$mod
 

--- a/R/mod.h.R
+++ b/R/mod.h.R
@@ -186,7 +186,9 @@ modResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "dep",
                     "pred",
                     "mod",
-                    "estMethod"),
+                    "estMethod",
+                    "bootstrap",
+                    "ciWidth"),
                 columns=list(
                     list(
                         `name`="term", 
@@ -243,7 +245,8 @@ modResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "pathDiagramEst",
                     "pathDiagramSig",
                     "mod",
-                    "estMethod")))
+                    "estMethod",
+                    "bootstrap")))
             self$add(R6::R6Class(
                 inherit = jmvcore::Group,
                 active = list(
@@ -265,7 +268,9 @@ modResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                 "dep",
                                 "pred",
                                 "mod",
-                                "estMethod"),
+                                "estMethod",
+                                "bootstrap",
+                                "ciWidth"),
                             columns=list(
                                 list(
                                     `name`="term", 
@@ -313,6 +318,7 @@ modResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                 "pred",
                                 "mod",
                                 "estMethod",
+                                "bootstrap",
                                 "ciWidth")))}))$new(options=options))
             private$..modelSyntax <- NULL},
         .setModelSyntax=function(x) private$..modelSyntax <- x))

--- a/R/mod.h.R
+++ b/R/mod.h.R
@@ -169,6 +169,7 @@ modResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         mod = function() private$.items[["mod"]],
         pathDiagram = function() private$.items[["pathDiagram"]],
         simpleSlope = function() private$.items[["simpleSlope"]],
+        model = function() private$.items[["model"]],
         modelSyntax = function() private$..modelSyntax),
     private = list(
         ..modelSyntax = NA),
@@ -320,6 +321,17 @@ modResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                 "estMethod",
                                 "bootstrap",
                                 "ciWidth")))}))$new(options=options))
+            self$add(jmvcore::Preformatted$new(
+                options=options,
+                name="model",
+                visible=FALSE,
+                clearWith=list(
+                    "dep",
+                    "pred",
+                    "mod",
+                    "estMethod",
+                    "bootstrap",
+                    "ciWidth")))
             private$..modelSyntax <- NULL},
         .setModelSyntax=function(x) private$..modelSyntax <- x))
 
@@ -407,6 +419,7 @@ modBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   \code{results$pathDiagram} \tab \tab \tab \tab \tab an image \cr
 #'   \code{results$simpleSlope$estimates} \tab \tab \tab \tab \tab a table containing the simple slope estimates \cr
 #'   \code{results$simpleSlope$plot} \tab \tab \tab \tab \tab an image \cr
+#'   \code{results$model} \tab \tab \tab \tab \tab invisible element whose state caches the parameter estimates so display-option changes do not refit the model \cr
 #'   \code{results$modelSyntax} \tab \tab \tab \tab \tab the lavaan syntax used to fit the moderation model \cr
 #' }
 #'

--- a/jamovi/med.r.yaml
+++ b/jamovi/med.r.yaml
@@ -13,6 +13,8 @@ items:
         - pred
         - med
         - estMethod
+        - bootstrap
+        - ciWidth
 
       columns:
         - name: effect
@@ -70,6 +72,8 @@ items:
         - pred
         - med
         - estMethod
+        - bootstrap
+        - ciWidth
 
       columns:
         - name: var1
@@ -135,6 +139,7 @@ items:
         - pathDiagramSig
         - med
         - estMethod
+        - bootstrap
 
     - name: estPlot
       title: Estimate Plot
@@ -148,6 +153,7 @@ items:
         - pred
         - med
         - estMethod
+        - bootstrap
         - ciWidth
         - label
         

--- a/jamovi/med.r.yaml
+++ b/jamovi/med.r.yaml
@@ -157,6 +157,20 @@ items:
         - ciWidth
         - label
         
+    - name:  model
+      type:  Preformatted
+      visible: false
+      description: >-
+        invisible element whose state caches the parameter estimates so
+        display-option changes do not refit the model
+      clearWith:
+        - dep
+        - pred
+        - med
+        - estMethod
+        - bootstrap
+        - ciWidth
+
     - name:  modelSyntax
       type:  Property
       description: the lavaan syntax used to fit the mediation model

--- a/jamovi/mod.r.yaml
+++ b/jamovi/mod.r.yaml
@@ -13,6 +13,8 @@ items:
         - pred
         - mod
         - estMethod
+        - bootstrap
+        - ciWidth
 
       columns:
         - name: term
@@ -70,6 +72,7 @@ items:
         - pathDiagramSig
         - mod
         - estMethod
+        - bootstrap
 
     - name: simpleSlope
       title: Simple Slope Analysis
@@ -85,6 +88,8 @@ items:
             - pred
             - mod
             - estMethod
+            - bootstrap
+            - ciWidth
     
           columns:
             - name: term
@@ -132,6 +137,7 @@ items:
             - pred
             - mod
             - estMethod
+            - bootstrap
             - ciWidth
               
     - name:  modelSyntax

--- a/jamovi/mod.r.yaml
+++ b/jamovi/mod.r.yaml
@@ -140,6 +140,20 @@ items:
             - bootstrap
             - ciWidth
               
+    - name:  model
+      type:  Preformatted
+      visible: false
+      description: >-
+        invisible element whose state caches the parameter estimates so
+        display-option changes do not refit the model
+      clearWith:
+        - dep
+        - pred
+        - mod
+        - estMethod
+        - bootstrap
+        - ciWidth
+
     - name:  modelSyntax
       type:  Property
       description: the lavaan syntax used to fit the moderation model

--- a/man/med.Rd
+++ b/man/med.Rd
@@ -80,6 +80,7 @@ A results object containing:
   \code{results$paths} \tab \tab \tab \tab \tab a table containing the individual path estimates \cr
   \code{results$pathDiagram} \tab \tab \tab \tab \tab an image \cr
   \code{results$estPlot} \tab \tab \tab \tab \tab an image \cr
+  \code{results$model} \tab \tab \tab \tab \tab invisible element whose state caches the parameter estimates so display-option changes do not refit the model \cr
   \code{results$modelSyntax} \tab \tab \tab \tab \tab the lavaan syntax used to fit the mediation model \cr
 }
 

--- a/man/mod.Rd
+++ b/man/mod.Rd
@@ -80,6 +80,7 @@ A results object containing:
   \code{results$pathDiagram} \tab \tab \tab \tab \tab an image \cr
   \code{results$simpleSlope$estimates} \tab \tab \tab \tab \tab a table containing the simple slope estimates \cr
   \code{results$simpleSlope$plot} \tab \tab \tab \tab \tab an image \cr
+  \code{results$model} \tab \tab \tab \tab \tab invisible element whose state caches the parameter estimates so display-option changes do not refit the model \cr
   \code{results$modelSyntax} \tab \tab \tab \tab \tab the lavaan syntax used to fit the moderation model \cr
 }
 


### PR DESCRIPTION
Makes the analyses stateful: the model estimates are cached and only recomputed when an option that actually affects them changes — so with bootstrap SEs, toggling display options no longer re-runs the (slow) bootstrap.

- **Estimates cache**: an invisible `Preformatted` result (`model`) stores lavaan's `parameterestimates()` table as element state, with `clearWith: [dep, pred, med/mod, estMethod, bootstrap, ciWidth]`. Toggling labels, plots, diagram options, CI/test columns etc. repopulates from the cached table instead of refitting. The state holds no lavaan object and no copy of the data, so it stays a few KB regardless of dataset size, and nothing lavaan-internal is ever serialized. (jmvcore 2.7.7's dedicated `State` type can't be constructed — its internal `super$initialize()` omits the required `refs` argument — hence the invisible `Preformatted` stand-in.)
- **Staleness fix (separate commit)**: `ciWidth` and `bootstrap` were missing from the estimate tables'/plots' `clearWith`, so changing them could leave stale CI bounds via the `isFilled()` early return. All estimate-displaying elements now clear on both; the path diagrams clear on `bootstrap` (significance stars depend on the SEs).
- Deliberate trade-off: `ciWidth` is part of the cache key, so changing the confidence level *does* refit (bootstrap CIs at a new level genuinely need the draws). An earlier revision kept the draws and reimplemented lavaan's percentile interpolation to make `ciWidth` changes instant too, but the extra ~150 lines and the duplication of lavaan's conventions weren't worth it for a set-once option.
- Known minor limitation: changing the bootstrap sample count clears the cache even under `estMethod = 'standard'`, where it's irrelevant — `clearWith` can't express conditionals; standard fits are fast so this is harmless.

R-facing behavior is unchanged (fresh analysis per call), guarded by the existing test suite. **Manual verification in jamovi** (the caching is only observable across live option changes): run with `estMethod = 'bootstrap'` and ~5000 samples, then toggle labels/plots/diagram options — updates should be instant (changing `ciWidth` refits, by design); edit a data cell to confirm results refresh; save and reopen an `.omv` to confirm the state behaves.
