### PR TITLE
Note win-builder result and Rosseel false positive

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -20,6 +20,7 @@ resolved in this release:
 
 * macOS (release), Windows (release), Ubuntu (release, devel, oldrel-1)
   via GitHub Actions
+* win-builder (devel)
 * local macOS, R release
 
 ## R CMD check results
@@ -27,4 +28,5 @@ resolved in this release:
 0 errors | 0 warnings
 
 The only NOTE is the expected new-submission NOTE (package was archived
-on CRAN).
+on CRAN). The word flagged as possibly misspelled in the DESCRIPTION
+(Rosseel) is the surname of the author of the lavaan package.


### PR DESCRIPTION
win-builder (devel) came back with Status: 1 NOTE — only the expected new-submission/archived NOTE, plus a spell-check false positive on "Rosseel" (the lavaan author's surname). Record both in cran-comments.md so the submission comment covers them. Build-ignored file, so the v1.2.0 tarball and tag are unaffected.