### PR TITLE
Improve documentation for CRAN resubmission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,11 +6,13 @@ Date: 2026-07-14
 Authors@R: person("Ravi", "Selker", email = "selker.ravi@gmail.com",
     role = c("aut", "cre"))
 Description: This toolbox allows you to do simple mediation and moderation
-    analysis. It is also available as a module for 'jamovi'
-    (see <https://www.jamovi.org> for more information). 'Medmod' is based
-    on the 'lavaan' package by Yves Rosseel. You can find an in depth tutorial
-    on the 'lavaan' model syntax used for this package on
-    <https://lavaan.ugent.be/tutorial/index.html>.
+    analysis. Models are estimated with the 'lavaan' package by Rosseel (2012)
+    <doi:10.18637/jss.v048.i02>; standard errors for the mediation estimates
+    are computed with the delta method following Sobel (1982)
+    <doi:10.2307/270723> or by bootstrapping. It is also available as a module
+    for 'jamovi' (see <https://www.jamovi.org> for more information). You can
+    find an in depth tutorial on the 'lavaan' model syntax used for this
+    package on <https://lavaan.ugent.be/tutorial/index.html>.
 License: GPL (>= 2)
 Encoding: UTF-8
 Depends:

--- a/R/med.b.R
+++ b/R/med.b.R
@@ -33,11 +33,11 @@ medClass <- R6::R6Class(
         #### Compute results ----
         .compute = function(data) {
             # the estimates only depend on the variables, the estimation
-            # options and the CI level (the model cache's clearWith), so
-            # reuse them across other option changes -- refitting is
-            # expensive with bootstrap SEs. Only lavaan's estimates table is
-            # kept, so the state size does not grow with the data
-            est <- self$results$model$state
+            # options and the CI level (the main table's clearWith), so
+            # cache them in the table's state across other option changes --
+            # refitting is expensive with bootstrap SEs. Only lavaan's estimates
+            # table is kept, so the state size does not grow with the data
+            est <- self$results$med$state
 
             if (is.null(est)) {
                 model <- private$.lavaanify()
@@ -53,7 +53,7 @@ medClass <- R6::R6Class(
                     level = self$options$ciWidth / 100
                 )
 
-                self$results$model$setState(est)
+                self$results$med$setState(est)
             }
 
             return(list('est' = est))

--- a/R/med.h.R
+++ b/R/med.h.R
@@ -170,7 +170,6 @@ medResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         paths = function() private$.items[["paths"]],
         pathDiagram = function() private$.items[["pathDiagram"]],
         estPlot = function() private$.items[["estPlot"]],
-        model = function() private$.items[["model"]],
         modelSyntax = function() private$..modelSyntax),
     private = list(
         ..modelSyntax = NA),
@@ -331,17 +330,6 @@ medResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "bootstrap",
                     "ciWidth",
                     "label")))
-            self$add(jmvcore::Preformatted$new(
-                options=options,
-                name="model",
-                visible=FALSE,
-                clearWith=list(
-                    "dep",
-                    "pred",
-                    "med",
-                    "estMethod",
-                    "bootstrap",
-                    "ciWidth")))
             private$..modelSyntax <- NULL},
         .setModelSyntax=function(x) private$..modelSyntax <- x))
 
@@ -434,7 +422,6 @@ medBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   \code{results$paths} \tab \tab \tab \tab \tab a table containing the individual path estimates \cr
 #'   \code{results$pathDiagram} \tab \tab \tab \tab \tab an image \cr
 #'   \code{results$estPlot} \tab \tab \tab \tab \tab an image \cr
-#'   \code{results$model} \tab \tab \tab \tab \tab invisible element whose state caches the parameter estimates so display-option changes do not refit the model \cr
 #'   \code{results$modelSyntax} \tab \tab \tab \tab \tab the lavaan syntax used to fit the mediation model \cr
 #' }
 #'

--- a/R/med.h.R
+++ b/R/med.h.R
@@ -368,7 +368,13 @@ medBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 
 #' Mediation
 #'
-#' Simple mediation analysis
+#' Simple mediation analysis. Estimates the indirect, direct and total effects 
+#' of a model in which a predictor influences the dependent variable through a 
+#' mediator. The model is fitted with the lavaan package (Rosseel, 2012); 
+#' standard errors are computed with the delta method (equivalent to the Sobel 
+#' test for the indirect effect) or by bootstrapping. Optionally provides the 
+#' individual path estimates, an estimate plot, and an annotated path diagram 
+#' of the model.
 #'
 #' @examples
 #' set.seed(1234)

--- a/R/medmod.R
+++ b/R/medmod.R
@@ -3,16 +3,10 @@
 #' @importFrom R6 R6Class
 NULL
 
-#' medmod: Simple Mediation and Moderation Analysis
-#'
-#' A package for simple mediation and moderation based on the \code{\link[lavaan]{lavaan}}
-#' package by Yves Rosseel. Medmod is also available as a
-#' module for 'jamovi' (see \href{https://www.jamovi.org}{www.jamovi.org} for
-#' more information).
-#'
-#' \tabular{llllll}{
-#'   Simple mediation analysis \tab \tab \tab \tab \code{\link{med}()} \cr
-#'   Simple moderation analysis \tab \tab \tab \tab \code{\link{mod}()} \cr
+#' @details
+#' \tabular{ll}{
+#'   Simple mediation analysis \tab \code{\link{med}()} \cr
+#'   Simple moderation analysis \tab \code{\link{mod}()} \cr
 #' }
 #'
 "_PACKAGE"

--- a/R/mod.b.R
+++ b/R/mod.b.R
@@ -33,11 +33,11 @@ modClass <- R6::R6Class(
         #### Compute results ----
         .compute = function(data) {
             # the estimates only depend on the variables, the estimation
-            # options and the CI level (the model cache's clearWith), so
-            # reuse them across other option changes -- refitting is
-            # expensive with bootstrap SEs. Only lavaan's estimates table is
-            # kept, so the state size does not grow with the data
-            est <- self$results$model$state
+            # options and the CI level (the main table's clearWith), so
+            # cache them in the table's state across other option changes --
+            # refitting is expensive with bootstrap SEs. Only lavaan's estimates
+            # table is kept, so the state size does not grow with the data
+            est <- self$results$mod$state
 
             if (is.null(est)) {
                 model <- private$.lavaanify()
@@ -53,7 +53,7 @@ modClass <- R6::R6Class(
                     level = self$options$ciWidth / 100
                 )
 
-                self$results$model$setState(est)
+                self$results$mod$setState(est)
             }
 
             return(list('est' = est))

--- a/R/mod.h.R
+++ b/R/mod.h.R
@@ -358,7 +358,13 @@ modBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 
 #' Moderation
 #'
-#' Simple mediation analysis
+#' Simple moderation analysis. Estimates a model in which the effect of a 
+#' predictor on the dependent variable depends on the value of a moderator, 
+#' testing the main effects of predictor and moderator and their interaction. 
+#' All variables are mean-centered before the model is fitted with the lavaan 
+#' package (Rosseel, 2012); standard errors are computed with the delta method 
+#' or by bootstrapping. Optionally provides a simple slope analysis with a 
+#' corresponding plot, and an annotated path diagram of the model.
 #'
 #' @examples
 #' set.seed(1234)

--- a/R/mod.h.R
+++ b/R/mod.h.R
@@ -169,7 +169,6 @@ modResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         mod = function() private$.items[["mod"]],
         pathDiagram = function() private$.items[["pathDiagram"]],
         simpleSlope = function() private$.items[["simpleSlope"]],
-        model = function() private$.items[["model"]],
         modelSyntax = function() private$..modelSyntax),
     private = list(
         ..modelSyntax = NA),
@@ -321,17 +320,6 @@ modResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                                 "estMethod",
                                 "bootstrap",
                                 "ciWidth")))}))$new(options=options))
-            self$add(jmvcore::Preformatted$new(
-                options=options,
-                name="model",
-                visible=FALSE,
-                clearWith=list(
-                    "dep",
-                    "pred",
-                    "mod",
-                    "estMethod",
-                    "bootstrap",
-                    "ciWidth")))
             private$..modelSyntax <- NULL},
         .setModelSyntax=function(x) private$..modelSyntax <- x))
 
@@ -425,7 +413,6 @@ modBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   \code{results$pathDiagram} \tab \tab \tab \tab \tab an image \cr
 #'   \code{results$simpleSlope$estimates} \tab \tab \tab \tab \tab a table containing the simple slope estimates \cr
 #'   \code{results$simpleSlope$plot} \tab \tab \tab \tab \tab an image \cr
-#'   \code{results$model} \tab \tab \tab \tab \tab invisible element whose state caches the parameter estimates so display-option changes do not refit the model \cr
 #'   \code{results$modelSyntax} \tab \tab \tab \tab \tab the lavaan syntax used to fit the moderation model \cr
 #' }
 #'

--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -16,14 +16,28 @@ analyses:
     ns: medmod
     menuGroup: medmod
     menuTitle: Mediation
-    description: Simple mediation analysis
+    description: >-
+      Simple mediation analysis. Estimates the indirect, direct and total
+      effects of a model in which a predictor influences the dependent variable
+      through a mediator. The model is fitted with the lavaan package (Rosseel,
+      2012); standard errors are computed with the delta method (equivalent to
+      the Sobel test for the indirect effect) or by bootstrapping. Optionally
+      provides the individual path estimates, an estimate plot, and an annotated
+      path diagram of the model.
     category: analyses
   - title: Moderation
     name: mod
     ns: medmod
     menuGroup: medmod
     menuTitle: Moderation
-    description: Simple mediation analysis
+    description: >-
+      Simple moderation analysis. Estimates a model in which the effect of a
+      predictor on the dependent variable depends on the value of a moderator,
+      testing the main effects of predictor and moderator and their interaction.
+      All variables are mean-centered before the model is fitted with the lavaan
+      package (Rosseel, 2012); standard errors are computed with the delta
+      method or by bootstrapping. Optionally provides a simple slope analysis
+      with a corresponding plot, and an annotated path diagram of the model.
     category: analyses
 datasets:
   - name: Exercise and Happiness

--- a/jamovi/med.a.yaml
+++ b/jamovi/med.a.yaml
@@ -6,7 +6,14 @@ version: '1.0.0'
 jas: '1.2'
 
 description:
-    main: Simple mediation analysis
+    main: >-
+        Simple mediation analysis. Estimates the indirect, direct and total
+        effects of a model in which a predictor influences the dependent
+        variable through a mediator. The model is fitted with the lavaan
+        package (Rosseel, 2012); standard errors are computed with the delta
+        method (equivalent to the Sobel test for the indirect effect) or by
+        bootstrapping. Optionally provides the individual path estimates, an
+        estimate plot, and an annotated path diagram of the model.
     R:
         dontrun: false
         usage: |

--- a/jamovi/med.r.yaml
+++ b/jamovi/med.r.yaml
@@ -157,20 +157,6 @@ items:
         - ciWidth
         - label
         
-    - name:  model
-      type:  Preformatted
-      visible: false
-      description: >-
-        invisible element whose state caches the parameter estimates so
-        display-option changes do not refit the model
-      clearWith:
-        - dep
-        - pred
-        - med
-        - estMethod
-        - bootstrap
-        - ciWidth
-
     - name:  modelSyntax
       type:  Property
       description: the lavaan syntax used to fit the mediation model

--- a/jamovi/mod.a.yaml
+++ b/jamovi/mod.a.yaml
@@ -6,7 +6,15 @@ version: '1.0.0'
 jas: '1.2'
 
 description:
-    main: Simple mediation analysis
+    main: >-
+        Simple moderation analysis. Estimates a model in which the effect of a
+        predictor on the dependent variable depends on the value of a
+        moderator, testing the main effects of predictor and moderator and
+        their interaction. All variables are mean-centered before the model is
+        fitted with the lavaan package (Rosseel, 2012); standard errors are
+        computed with the delta method or by bootstrapping. Optionally
+        provides a simple slope analysis with a corresponding plot, and an
+        annotated path diagram of the model.
     R:
         dontrun: false
         usage: |

--- a/jamovi/mod.r.yaml
+++ b/jamovi/mod.r.yaml
@@ -140,20 +140,6 @@ items:
             - bootstrap
             - ciWidth
               
-    - name:  model
-      type:  Preformatted
-      visible: false
-      description: >-
-        invisible element whose state caches the parameter estimates so
-        display-option changes do not refit the model
-      clearWith:
-        - dep
-        - pred
-        - mod
-        - estMethod
-        - bootstrap
-        - ciWidth
-
     - name:  modelSyntax
       type:  Property
       description: the lavaan syntax used to fit the moderation model

--- a/man/med.Rd
+++ b/man/med.Rd
@@ -80,7 +80,6 @@ A results object containing:
   \code{results$paths} \tab \tab \tab \tab \tab a table containing the individual path estimates \cr
   \code{results$pathDiagram} \tab \tab \tab \tab \tab an image \cr
   \code{results$estPlot} \tab \tab \tab \tab \tab an image \cr
-  \code{results$model} \tab \tab \tab \tab \tab invisible element whose state caches the parameter estimates so display-option changes do not refit the model \cr
   \code{results$modelSyntax} \tab \tab \tab \tab \tab the lavaan syntax used to fit the mediation model \cr
 }
 

--- a/man/med.Rd
+++ b/man/med.Rd
@@ -91,7 +91,13 @@ Tables can be converted to data frames with \code{asDF} or \code{\link{as.data.f
 \code{as.data.frame(results$med)}
 }
 \description{
-Simple mediation analysis
+Simple mediation analysis. Estimates the indirect, direct and total effects 
+of a model in which a predictor influences the dependent variable through a 
+mediator. The model is fitted with the lavaan package (Rosseel, 2012); 
+standard errors are computed with the delta method (equivalent to the Sobel 
+test for the indirect effect) or by bootstrapping. Optionally provides the 
+individual path estimates, an estimate plot, and an annotated path diagram 
+of the model.
 }
 \examples{
 set.seed(1234)

--- a/man/medmod-package.Rd
+++ b/man/medmod-package.Rd
@@ -6,15 +6,12 @@
 \alias{medmod-package}
 \title{medmod: Simple Mediation and Moderation Analysis}
 \description{
-A package for simple mediation and moderation based on the \code{\link[lavaan]{lavaan}}
-package by Yves Rosseel. Medmod is also available as a
-module for 'jamovi' (see \href{https://www.jamovi.org}{www.jamovi.org} for
-more information).
+This toolbox allows you to do simple mediation and moderation analysis. Models are estimated with the 'lavaan' package by Rosseel (2012) \doi{10.18637/jss.v048.i02}; standard errors for the mediation estimates are computed with the delta method following Sobel (1982) \doi{10.2307/270723} or by bootstrapping. It is also available as a module for 'jamovi' (see \url{https://www.jamovi.org} for more information). You can find an in depth tutorial on the 'lavaan' model syntax used for this package on \url{https://lavaan.ugent.be/tutorial/index.html}.
 }
 \details{
-\tabular{llllll}{
-  Simple mediation analysis \tab \tab \tab \tab \code{\link{med}()} \cr
-  Simple moderation analysis \tab \tab \tab \tab \code{\link{mod}()} \cr
+\tabular{ll}{
+  Simple mediation analysis \tab \code{\link{med}()} \cr
+  Simple moderation analysis \tab \code{\link{mod}()} \cr
 }
 }
 \seealso{

--- a/man/mod.Rd
+++ b/man/mod.Rd
@@ -91,7 +91,13 @@ Tables can be converted to data frames with \code{asDF} or \code{\link{as.data.f
 \code{as.data.frame(results$mod)}
 }
 \description{
-Simple mediation analysis
+Simple moderation analysis. Estimates a model in which the effect of a 
+predictor on the dependent variable depends on the value of a moderator, 
+testing the main effects of predictor and moderator and their interaction. 
+All variables are mean-centered before the model is fitted with the lavaan 
+package (Rosseel, 2012); standard errors are computed with the delta method 
+or by bootstrapping. Optionally provides a simple slope analysis with a 
+corresponding plot, and an annotated path diagram of the model.
 }
 \examples{
 set.seed(1234)

--- a/man/mod.Rd
+++ b/man/mod.Rd
@@ -80,7 +80,6 @@ A results object containing:
   \code{results$pathDiagram} \tab \tab \tab \tab \tab an image \cr
   \code{results$simpleSlope$estimates} \tab \tab \tab \tab \tab a table containing the simple slope estimates \cr
   \code{results$simpleSlope$plot} \tab \tab \tab \tab \tab an image \cr
-  \code{results$model} \tab \tab \tab \tab \tab invisible element whose state caches the parameter estimates so display-option changes do not refit the model \cr
   \code{results$modelSyntax} \tab \tab \tab \tab \tab the lavaan syntax used to fit the moderation model \cr
 }
 


### PR DESCRIPTION
## Summary

Pre-empts the two most common CRAN reviewer requests and cleans up the generated R docs, following the win-builder pass.

### Expand analysis descriptions and add references
- `med`/`mod` descriptions grow from one line to a real summary of what each analysis estimates, the estimation options, and the available outputs — this flows into the Rd files and the jamovi menu
- Fixes a copy-paste bug: the Moderation analysis described itself as *"Simple mediation analysis"* in `mod.Rd` and the module manifest
- DESCRIPTION now cites Rosseel (2012) `<doi:10.18637/jss.v048.i02>` and Sobel (1982) `<doi:10.2307/270723>` — the `Authors (year) <doi:...>` format CRAN reviewers ask for

### Cache estimates in the main table state
- The invisible `model` carrier element leaked into the Rd `\value` section as *"results$model — invisible element whose state caches..."*, meaningless to R users
- The main estimates table has exactly the cache key as its `clearWith`, so the cached lavaan estimates now ride in its state instead; the extra element is gone from the results object and the docs
- Behavior-neutral: same cache key, same invalidation

## Verification
- `R CMD check --as-cran`: 1 NOTE (the unavoidable new-submission/archived one)
- 34/34 tests pass

## After merge
Move the `v1.2.0` tag to the merged commit and rebuild the submission tarball — nothing has shipped to CRAN yet, so the fresh tag is free.